### PR TITLE
Fixed NuGet version mismatch

### DIFF
--- a/Source/Wintellect.Analyzers/Wintellect.Analyzers/Wintellect.Analyzers.csproj
+++ b/Source/Wintellect.Analyzers/Wintellect.Analyzers/Wintellect.Analyzers.csproj
@@ -143,7 +143,7 @@
     <GetAssemblyIdentity AssemblyFiles="$(OutDir)\$(AssemblyName).dll">
       <Output TaskParameter="Assemblies" ItemName="Analyzer1AssemblyInfo" />
     </GetAssemblyIdentity>
-    <Exec Command="&quot;$(SolutionDir)packages\NuGet.CommandLine.2.8.6\tools\NuGet.exe&quot; pack Wintellect.Analyzers.nuspec -NoPackageAnalysis -Version %(Analyzer1AssemblyInfo.Version) -OutputDirectory ." WorkingDirectory="$(OutDir)" LogStandardErrorAsError="true" ConsoleToMSBuild="true">
+    <Exec Command="&quot;$(SolutionDir)packages\NuGet.CommandLine.2.8.5\tools\NuGet.exe&quot; pack Wintellect.Analyzers.nuspec -NoPackageAnalysis -Version %(Analyzer1AssemblyInfo.Version) -OutputDirectory ." WorkingDirectory="$(OutDir)" LogStandardErrorAsError="true" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
     </Exec>
   </Target>


### PR DESCRIPTION
The target added by NuGet to the project file is hard-coded to a specific NuGet version. However, this didn't match the version of NuGet referenced in the packages.config causing the build to fail (unless you happen to have manually installed NuGet version 2.8.6 too)